### PR TITLE
generate spanner query functions use an interface

### DIFF
--- a/examples/spanner/basic/basic_example.persist.go
+++ b/examples/spanner/basic/basic_example.persist.go
@@ -207,14 +207,14 @@ func (s *MySpannerImpl) UniaryInsert(ctx context.Context, req *test.ExampleTable
 	var err error
 	_ = err
 	params := &persist_lib.Test_ExampleTableForMySpanner{}
-	// set 'ExampleTable.id' in params
-	params.Id = req.Id
 	// set 'ExampleTable.start_time' in params
 	if params.StartTime, err = (mytime.MyTime{}).ToSpanner(req.StartTime).SpannerValue(); err != nil {
 		return nil, gstatus.Errorf(codes.Unknown, "could not convert type to persist_lib type: %v, err", err)
 	}
 	// set 'ExampleTable.name' in params
 	params.Name = req.Name
+	// set 'ExampleTable.id' in params
+	params.Id = req.Id
 	var res = test.ExampleTable{}
 	var iterErr error
 	_ = iterErr
@@ -361,6 +361,18 @@ func (s *MySpannerImpl) TestEverything(ctx context.Context, req *HasTimestamp) (
 	var err error
 	_ = err
 	params := &persist_lib.HasTimestampForMySpanner{}
+	// set 'HasTimestamp.tables' in params
+	{
+		var bytesOfBytes [][]byte
+		for _, msg := range req.Tables {
+			raw, err := proto.Marshal(msg)
+			if err != nil {
+				return nil, gstatus.Errorf(codes.Unknown, "could not convert type to [][]byte, err: %s", err)
+			}
+			bytesOfBytes = append(bytesOfBytes, raw)
+		}
+		params.Tables = bytesOfBytes
+	}
 	// set 'HasTimestamp.time' in params
 	if params.Time, err = (mytime.MyTime{}).ToSpanner(req.Time).SpannerValue(); err != nil {
 		return nil, gstatus.Errorf(codes.Unknown, "could not convert type to persist_lib type: %v, err", err)
@@ -409,18 +421,6 @@ func (s *MySpannerImpl) TestEverything(ctx context.Context, req *HasTimestamp) (
 	}
 	// set 'HasTimestamp.strs' in params
 	params.Strs = req.Strs
-	// set 'HasTimestamp.tables' in params
-	{
-		var bytesOfBytes [][]byte
-		for _, msg := range req.Tables {
-			raw, err := proto.Marshal(msg)
-			if err != nil {
-				return nil, gstatus.Errorf(codes.Unknown, "could not convert type to [][]byte, err: %s", err)
-			}
-			bytesOfBytes = append(bytesOfBytes, raw)
-		}
-		params.Tables = bytesOfBytes
-	}
 	var res = HasTimestamp{}
 	var iterErr error
 	_ = iterErr
@@ -539,10 +539,10 @@ func (s *MySpannerImpl) UniarySelectWithDirectives(ctx context.Context, req *tes
 	var err error
 	_ = err
 	params := &persist_lib.Test_ExampleTableForMySpanner{}
-	// set 'ExampleTable.name' in params
-	params.Name = req.Name
 	// set 'ExampleTable.id' in params
 	params.Id = req.Id
+	// set 'ExampleTable.name' in params
+	params.Name = req.Name
 	var res = test.ExampleTable{}
 	var iterErr error
 	_ = iterErr
@@ -595,14 +595,14 @@ func (s *MySpannerImpl) UniaryUpdate(ctx context.Context, req *test.ExampleTable
 	var err error
 	_ = err
 	params := &persist_lib.Test_ExampleTableForMySpanner{}
-	// set 'ExampleTable.name' in params
-	params.Name = req.Name
-	// set 'ExampleTable.id' in params
-	params.Id = req.Id
 	// set 'ExampleTable.start_time' in params
 	if params.StartTime, err = (mytime.MyTime{}).ToSpanner(req.StartTime).SpannerValue(); err != nil {
 		return nil, gstatus.Errorf(codes.Unknown, "could not convert type to persist_lib type: %v, err", err)
 	}
+	// set 'ExampleTable.name' in params
+	params.Name = req.Name
+	// set 'ExampleTable.id' in params
+	params.Id = req.Id
 	var res = test.PartialTable{}
 	var iterErr error
 	_ = iterErr
@@ -644,10 +644,10 @@ func (s *MySpannerImpl) UniaryDeleteRange(ctx context.Context, req *test.Example
 	var err error
 	_ = err
 	params := &persist_lib.Test_ExampleTableRangeForMySpanner{}
-	// set 'ExampleTableRange.end_id' in params
-	params.EndId = req.EndId
 	// set 'ExampleTableRange.start_id' in params
 	params.StartId = req.StartId
+	// set 'ExampleTableRange.end_id' in params
+	params.EndId = req.EndId
 	var res = test.ExampleTable{}
 	var iterErr error
 	_ = iterErr
@@ -955,14 +955,14 @@ func (s *MySpannerImpl) ClientStreamUpdate(stream MySpanner_ClientStreamUpdateSe
 			return gstatus.Errorf(codes.Unknown, "error recieving input: %v", err)
 		}
 		params := &persist_lib.Test_ExampleTableForMySpanner{}
-		// set 'ExampleTable.id' in params
-		params.Id = req.Id
 		// set 'ExampleTable.start_time' in params
 		if params.StartTime, err = (mytime.MyTime{}).ToSpanner(req.StartTime).SpannerValue(); err != nil {
 			return gstatus.Errorf(codes.Unknown, "could not convert type to persist_lib type: %v, err", err)
 		}
 		// set 'ExampleTable.name' in params
 		params.Name = req.Name
+		// set 'ExampleTable.id' in params
+		params.Id = req.Id
 		feed(params)
 	}
 	row, err := stop()

--- a/examples/spanner/basic/persist_lib/basic_example_queries.persist.go
+++ b/examples/spanner/basic/persist_lib/basic_example_queries.persist.go
@@ -2,158 +2,239 @@ package persist_lib
 
 import "cloud.google.com/go/spanner"
 
-func NumRowsFromExtraUnaryQuery(req *Test_NumRowsForExtraSrv) spanner.Statement {
+func NumRowsFromExtraUnaryQuery(req NumRowsFromExtraUnaryQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL:    "SELECT * FROM extra_unary",
 		Params: map[string]interface{}{},
 	}
 }
-func ExampleTableFromUniaryInsertQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromUniaryInsertQuery(req ExampleTableFromUniaryInsertQueryParams) *spanner.Mutation {
 	return spanner.InsertMap("example_table", map[string]interface{}{
 		"name":       "bananas",
-		"id":         req.Id,
-		"start_time": req.StartTime,
+		"id":         req.GetId(),
+		"start_time": req.GetStartTime(),
 	})
 }
-func ExampleTableFromUniarySelectQuery(req *Test_ExampleTableForMySpanner) spanner.Statement {
+func ExampleTableFromUniarySelectQuery(req ExampleTableFromUniarySelectQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL: "SELECT * from example_table Where id=@id AND name=@name",
 		Params: map[string]interface{}{
-			"@id":   req.Id,
-			"@name": req.Name,
+			"@id":   req.GetId(),
+			"@name": req.GetName(),
 		},
 	}
 }
-func SomethingFromTestNestQuery(req *SomethingForMySpanner) spanner.Statement {
+func SomethingFromTestNestQuery(req SomethingFromTestNestQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL: "SELECT * from example_table Where id=@thing",
 		Params: map[string]interface{}{
-			"@thing": req.Thing,
+			"@thing": req.GetThing(),
 		},
 	}
 }
-func HasTimestampFromTestEverythingQuery(req *HasTimestampForMySpanner) spanner.Statement {
+func HasTimestampFromTestEverythingQuery(req HasTimestampFromTestEverythingQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL: "SELECT * from example_table Where id=@time AND some=@some AND str=@str AND table=@table AND times = @times AND somes = @somes AND strs = @strs AND tables = @tables",
 		Params: map[string]interface{}{
-			"@time":   req.Time,
-			"@some":   req.Some,
-			"@str":    req.Str,
-			"@table":  req.Table,
-			"@times":  req.Times,
-			"@somes":  req.Somes,
-			"@strs":   req.Strs,
-			"@tables": req.Tables,
+			"@time":   req.GetTime(),
+			"@some":   req.GetSome(),
+			"@str":    req.GetStr(),
+			"@table":  req.GetTable(),
+			"@times":  req.GetTimes(),
+			"@somes":  req.GetSomes(),
+			"@strs":   req.GetStrs(),
+			"@tables": req.GetTables(),
 		},
 	}
 }
-func ExampleTableFromUniarySelectWithDirectivesQuery(req *Test_ExampleTableForMySpanner) spanner.Statement {
+func ExampleTableFromUniarySelectWithDirectivesQuery(req ExampleTableFromUniarySelectWithDirectivesQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL: "SELECT * from example_table@{FORCE_INDEX=index} Where id=@id AND name=@name",
 		Params: map[string]interface{}{
-			"@id":   req.Id,
-			"@name": req.Name,
+			"@id":   req.GetId(),
+			"@name": req.GetName(),
 		},
 	}
 }
-func ExampleTableFromUniaryUpdateQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromUniaryUpdateQuery(req ExampleTableFromUniaryUpdateQueryParams) *spanner.Mutation {
 	return spanner.UpdateMap("example_table", map[string]interface{}{
-		"start_time": req.StartTime,
+		"start_time": req.GetStartTime(),
 		"name":       "oranges",
-		"id":         req.Id,
+		"id":         req.GetId(),
 	})
 }
-func ExampleTableRangeFromUniaryDeleteRangeQuery(req *Test_ExampleTableRangeForMySpanner) *spanner.Mutation {
+func ExampleTableRangeFromUniaryDeleteRangeQuery(req ExampleTableRangeFromUniaryDeleteRangeQueryParams) *spanner.Mutation {
 	return spanner.Delete("example_table", spanner.KeyRange{
 		Start: spanner.Key{
-			req.StartId,
+			req.GetStartId(),
 		},
 		End: spanner.Key{
-			req.EndId,
+			req.GetEndId(),
 		},
 		Kind: spanner.ClosedOpen,
 	})
 }
-func ExampleTableFromUniaryDeleteSingleQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromUniaryDeleteSingleQuery(req ExampleTableFromUniaryDeleteSingleQueryParams) *spanner.Mutation {
 	return spanner.Delete("example_table", spanner.Key{
 		"abc",
 		123,
-		req.Id,
+		req.GetId(),
 	})
 }
-func ExampleTableFromNoArgsQuery(req *Test_ExampleTableForMySpanner) spanner.Statement {
+func ExampleTableFromNoArgsQuery(req ExampleTableFromNoArgsQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL:    "select * from example_table limit 1",
 		Params: map[string]interface{}{},
 	}
 }
-func NameFromServerStreamQuery(req *Test_NameForMySpanner) spanner.Statement {
+func NameFromServerStreamQuery(req NameFromServerStreamQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL:    "SELECT * FROM example_table",
 		Params: map[string]interface{}{},
 	}
 }
-func ExampleTableFromClientStreamInsertQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromClientStreamInsertQuery(req ExampleTableFromClientStreamInsertQueryParams) *spanner.Mutation {
 	return spanner.InsertMap("example_table", map[string]interface{}{
-		"id":         req.Id,
-		"start_time": req.StartTime,
+		"id":         req.GetId(),
+		"start_time": req.GetStartTime(),
 		"name":       3,
 	})
 }
-func ExampleTableFromClientStreamDeleteQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromClientStreamDeleteQuery(req ExampleTableFromClientStreamDeleteQueryParams) *spanner.Mutation {
 	return spanner.Delete("example_table", spanner.Key{
-		req.Id,
+		req.GetId(),
 	})
 }
-func ExampleTableFromClientStreamUpdateQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromClientStreamUpdateQuery(req ExampleTableFromClientStreamUpdateQueryParams) *spanner.Mutation {
 	return spanner.UpdateMap("example_table", map[string]interface{}{
-		"start_time": req.StartTime,
-		"name":       req.Name,
-		"id":         req.Id,
+		"start_time": req.GetStartTime(),
+		"name":       req.GetName(),
+		"id":         req.GetId(),
 	})
 }
-func ExampleTableFromUniaryInsertWithHooksQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromUniaryInsertWithHooksQuery(req ExampleTableFromUniaryInsertWithHooksQueryParams) *spanner.Mutation {
 	return spanner.InsertMap("example_table", map[string]interface{}{
-		"start_time": req.StartTime,
 		"name":       "bananas",
-		"id":         req.Id,
+		"id":         req.GetId(),
+		"start_time": req.GetStartTime(),
 	})
 }
-func ExampleTableFromUniarySelectWithHooksQuery(req *Test_ExampleTableForMySpanner) spanner.Statement {
+func ExampleTableFromUniarySelectWithHooksQuery(req ExampleTableFromUniarySelectWithHooksQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL: "SELECT * from example_table Where id=@id",
 		Params: map[string]interface{}{
-			"@id": req.Id,
+			"@id": req.GetId(),
 		},
 	}
 }
-func ExampleTableFromUniaryUpdateWithHooksQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromUniaryUpdateWithHooksQuery(req ExampleTableFromUniaryUpdateWithHooksQueryParams) *spanner.Mutation {
 	return spanner.UpdateMap("example_table", map[string]interface{}{
-		"start_time": req.StartTime,
+		"start_time": req.GetStartTime(),
 		"name":       "oranges",
-		"id":         req.Id,
+		"id":         req.GetId(),
 	})
 }
-func ExampleTableRangeFromUniaryDeleteWithHooksQuery(req *Test_ExampleTableRangeForMySpanner) *spanner.Mutation {
+func ExampleTableRangeFromUniaryDeleteWithHooksQuery(req ExampleTableRangeFromUniaryDeleteWithHooksQueryParams) *spanner.Mutation {
 	return spanner.Delete("example_table", spanner.KeyRange{
 		Start: spanner.Key{
-			req.StartId,
+			req.GetStartId(),
 		},
 		End: spanner.Key{
-			req.EndId,
+			req.GetEndId(),
 		},
 		Kind: spanner.ClosedOpen,
 	})
 }
-func NameFromServerStreamWithHooksQuery(req *Test_NameForMySpanner) spanner.Statement {
+func NameFromServerStreamWithHooksQuery(req NameFromServerStreamWithHooksQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL:    "SELECT * FROM example_table",
 		Params: map[string]interface{}{},
 	}
 }
-func ExampleTableFromClientStreamUpdateWithHooksQuery(req *Test_ExampleTableForMySpanner) *spanner.Mutation {
+func ExampleTableFromClientStreamUpdateWithHooksQuery(req ExampleTableFromClientStreamUpdateWithHooksQueryParams) *spanner.Mutation {
 	return spanner.UpdateMap("example_table", map[string]interface{}{
 		"name": "asdf",
-		"id":   req.Id,
+		"id":   req.GetId(),
 	})
+}
+
+type NumRowsFromExtraUnaryQueryParams interface {
+}
+type ExampleTableFromUniaryInsertQueryParams interface {
+	GetId() int64
+	GetStartTime() interface{}
+	GetName() string
+}
+type ExampleTableFromUniarySelectQueryParams interface {
+	GetId() int64
+	GetName() string
+}
+type SomethingFromTestNestQueryParams interface {
+	GetThing() []byte
+}
+type HasTimestampFromTestEverythingQueryParams interface {
+	GetStr() string
+	GetTable() []byte
+	GetTimes() [][]byte
+	GetSomes() [][]byte
+	GetStrs() []string
+	GetTables() [][]byte
+	GetTime() interface{}
+	GetSome() []byte
+}
+type ExampleTableFromUniarySelectWithDirectivesQueryParams interface {
+	GetId() int64
+	GetName() string
+}
+type ExampleTableFromUniaryUpdateQueryParams interface {
+	GetStartTime() interface{}
+	GetName() string
+	GetId() int64
+}
+type ExampleTableRangeFromUniaryDeleteRangeQueryParams interface {
+	GetEndId() int64
+	GetStartId() int64
+}
+type ExampleTableFromUniaryDeleteSingleQueryParams interface {
+	GetId() int64
+}
+type ExampleTableFromNoArgsQueryParams interface {
+}
+type NameFromServerStreamQueryParams interface {
+}
+type ExampleTableFromClientStreamInsertQueryParams interface {
+	GetId() int64
+	GetStartTime() interface{}
+	GetName() string
+}
+type ExampleTableFromClientStreamDeleteQueryParams interface {
+	GetId() int64
+}
+type ExampleTableFromClientStreamUpdateQueryParams interface {
+	GetStartTime() interface{}
+	GetName() string
+	GetId() int64
+}
+type ExampleTableFromUniaryInsertWithHooksQueryParams interface {
+	GetId() int64
+	GetStartTime() interface{}
+	GetName() string
+}
+type ExampleTableFromUniarySelectWithHooksQueryParams interface {
+	GetId() int64
+}
+type ExampleTableFromUniaryUpdateWithHooksQueryParams interface {
+	GetStartTime() interface{}
+	GetName() string
+	GetId() int64
+}
+type ExampleTableRangeFromUniaryDeleteWithHooksQueryParams interface {
+	GetStartId() int64
+	GetEndId() int64
+}
+type NameFromServerStreamWithHooksQueryParams interface {
+}
+type ExampleTableFromClientStreamUpdateWithHooksQueryParams interface {
+	GetName() string
+	GetId() int64
 }

--- a/examples/spanner/basic/persist_lib/pkg_level_definitions.persist.go
+++ b/examples/spanner/basic/persist_lib/pkg_level_definitions.persist.go
@@ -13,19 +13,47 @@ func NewSpannerClientGetter(cli *spanner.Client) SpannerClientGetter {
 type Test_NumRowsForExtraSrv struct {
 	Count int64
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *Test_NumRowsForExtraSrv) GetCount() int64      { return p.Count }
+func (p *Test_NumRowsForExtraSrv) SetCount(param int64) { p.Count = param }
+
 type Test_ExampleTableForExtraSrv struct {
 	Id        int64
 	StartTime []byte
 	Name      string
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *Test_ExampleTableForExtraSrv) GetId() int64              { return p.Id }
+func (p *Test_ExampleTableForExtraSrv) SetId(param int64)         { p.Id = param }
+func (p *Test_ExampleTableForExtraSrv) GetStartTime() []byte      { return p.StartTime }
+func (p *Test_ExampleTableForExtraSrv) SetStartTime(param []byte) { p.StartTime = param }
+func (p *Test_ExampleTableForExtraSrv) GetName() string           { return p.Name }
+func (p *Test_ExampleTableForExtraSrv) SetName(param string)      { p.Name = param }
+
 type Test_ExampleTableForMySpanner struct {
 	Id        int64
 	StartTime interface{}
 	Name      string
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *Test_ExampleTableForMySpanner) GetId() int64                   { return p.Id }
+func (p *Test_ExampleTableForMySpanner) SetId(param int64)              { p.Id = param }
+func (p *Test_ExampleTableForMySpanner) GetStartTime() interface{}      { return p.StartTime }
+func (p *Test_ExampleTableForMySpanner) SetStartTime(param interface{}) { p.StartTime = param }
+func (p *Test_ExampleTableForMySpanner) GetName() string                { return p.Name }
+func (p *Test_ExampleTableForMySpanner) SetName(param string)           { p.Name = param }
+
 type SomethingForMySpanner struct {
 	Thing []byte
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *SomethingForMySpanner) GetThing() []byte      { return p.Thing }
+func (p *SomethingForMySpanner) SetThing(param []byte) { p.Thing = param }
+
 type HasTimestampForMySpanner struct {
 	Time   interface{}
 	Some   []byte
@@ -36,10 +64,40 @@ type HasTimestampForMySpanner struct {
 	Somes  [][]byte
 	Times  [][]byte
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *HasTimestampForMySpanner) GetTime() interface{}      { return p.Time }
+func (p *HasTimestampForMySpanner) SetTime(param interface{}) { p.Time = param }
+func (p *HasTimestampForMySpanner) GetSome() []byte           { return p.Some }
+func (p *HasTimestampForMySpanner) SetSome(param []byte)      { p.Some = param }
+func (p *HasTimestampForMySpanner) GetStr() string            { return p.Str }
+func (p *HasTimestampForMySpanner) SetStr(param string)       { p.Str = param }
+func (p *HasTimestampForMySpanner) GetTable() []byte          { return p.Table }
+func (p *HasTimestampForMySpanner) SetTable(param []byte)     { p.Table = param }
+func (p *HasTimestampForMySpanner) GetStrs() []string         { return p.Strs }
+func (p *HasTimestampForMySpanner) SetStrs(param []string)    { p.Strs = param }
+func (p *HasTimestampForMySpanner) GetTables() [][]byte       { return p.Tables }
+func (p *HasTimestampForMySpanner) SetTables(param [][]byte)  { p.Tables = param }
+func (p *HasTimestampForMySpanner) GetSomes() [][]byte        { return p.Somes }
+func (p *HasTimestampForMySpanner) SetSomes(param [][]byte)   { p.Somes = param }
+func (p *HasTimestampForMySpanner) GetTimes() [][]byte        { return p.Times }
+func (p *HasTimestampForMySpanner) SetTimes(param [][]byte)   { p.Times = param }
+
 type Test_ExampleTableRangeForMySpanner struct {
 	StartId int64
 	EndId   int64
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *Test_ExampleTableRangeForMySpanner) GetStartId() int64      { return p.StartId }
+func (p *Test_ExampleTableRangeForMySpanner) SetStartId(param int64) { p.StartId = param }
+func (p *Test_ExampleTableRangeForMySpanner) GetEndId() int64        { return p.EndId }
+func (p *Test_ExampleTableRangeForMySpanner) SetEndId(param int64)   { p.EndId = param }
+
 type Test_NameForMySpanner struct {
 	Name string
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *Test_NameForMySpanner) GetName() string      { return p.Name }
+func (p *Test_NameForMySpanner) SetName(param string) { p.Name = param }

--- a/examples/spanner/bob_example/persist_lib/bobs_queries.persist.go
+++ b/examples/spanner/bob_example/persist_lib/bobs_queries.persist.go
@@ -2,36 +2,50 @@ package persist_lib
 
 import "cloud.google.com/go/spanner"
 
-func BobFromDeleteBobsQuery(req *BobForBobs) *spanner.Mutation {
+func BobFromDeleteBobsQuery(req BobFromDeleteBobsQueryParams) *spanner.Mutation {
 	return spanner.Delete("bob_table", spanner.KeyRange{
 		Start: spanner.Key{
 			"Bob",
 		},
 		End: spanner.Key{
 			"Bob",
-			req.StartTime,
+			req.GetStartTime(),
 		},
 		Kind: spanner.ClosedOpen,
 	})
 }
-func BobFromPutBobsQuery(req *BobForBobs) *spanner.Mutation {
+func BobFromPutBobsQuery(req BobFromPutBobsQueryParams) *spanner.Mutation {
 	return spanner.InsertMap("bob_table", map[string]interface{}{
-		"name":       req.Name,
-		"start_time": req.StartTime,
-		"id":         req.Id,
+		"id":         req.GetId(),
+		"name":       req.GetName(),
+		"start_time": req.GetStartTime(),
 	})
 }
-func EmptyFromGetBobsQuery(req *EmptyForBobs) spanner.Statement {
+func EmptyFromGetBobsQuery(req EmptyFromGetBobsQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL:    "SELECT * from bob_table",
 		Params: map[string]interface{}{},
 	}
 }
-func NamesFromGetPeopleFromNamesQuery(req *NamesForBobs) spanner.Statement {
+func NamesFromGetPeopleFromNamesQuery(req NamesFromGetPeopleFromNamesQueryParams) spanner.Statement {
 	return spanner.Statement{
 		SQL: "SELECT * FROM bob_table WHERE name IN UNNEST(@names)",
 		Params: map[string]interface{}{
-			"@names": req.Names,
+			"@names": req.GetNames(),
 		},
 	}
+}
+
+type BobFromDeleteBobsQueryParams interface {
+	GetStartTime() interface{}
+}
+type BobFromPutBobsQueryParams interface {
+	GetId() int64
+	GetName() string
+	GetStartTime() interface{}
+}
+type EmptyFromGetBobsQueryParams interface {
+}
+type NamesFromGetPeopleFromNamesQueryParams interface {
+	GetNames() []string
 }

--- a/examples/spanner/bob_example/persist_lib/pkg_level_definitions.persist.go
+++ b/examples/spanner/bob_example/persist_lib/pkg_level_definitions.persist.go
@@ -15,8 +15,23 @@ type BobForBobs struct {
 	StartTime interface{}
 	Name      string
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *BobForBobs) GetId() int64                   { return p.Id }
+func (p *BobForBobs) SetId(param int64)              { p.Id = param }
+func (p *BobForBobs) GetStartTime() interface{}      { return p.StartTime }
+func (p *BobForBobs) SetStartTime(param interface{}) { p.StartTime = param }
+func (p *BobForBobs) GetName() string                { return p.Name }
+func (p *BobForBobs) SetName(param string)           { p.Name = param }
+
 type EmptyForBobs struct {
 }
+
+// this could be used in a query, so generate the getters/setters
 type NamesForBobs struct {
 	Names []string
 }
+
+// this could be used in a query, so generate the getters/setters
+func (p *NamesForBobs) GetNames() []string      { return p.Names }
+func (p *NamesForBobs) SetNames(param []string) { p.Names = param }

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -55,8 +55,6 @@ func NewGenerator(request *plugin_go.CodeGeneratorRequest) *Generator {
 	ret.AllStructures = NewStructList()
 	ret.Files = NewFileList()
 	ret.Response = new(plugin_go.CodeGeneratorResponse)
-	param := request.GetParameter()
-	logrus.Warnf("the parameter string? %s\n", param)
 
 	return ret
 }

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -55,6 +55,9 @@ func NewGenerator(request *plugin_go.CodeGeneratorRequest) *Generator {
 	ret.AllStructures = NewStructList()
 	ret.Files = NewFileList()
 	ret.Response = new(plugin_go.CodeGeneratorResponse)
+	param := request.GetParameter()
+	logrus.Warnf("the parameter string? %s\n", param)
+
 	return ret
 }
 

--- a/generator/import.go
+++ b/generator/import.go
@@ -89,3 +89,6 @@ func (il *Imports) GetImportPkgForPath(path string) string {
 	}
 	return "__invalid__import__"
 }
+
+func WhoAmI(file *FileStruct) {
+}

--- a/generator/method.go
+++ b/generator/method.go
@@ -586,7 +586,7 @@ func (m *Method) Process() error {
 		// WE REALLY SHOULD PUT THIS PART IN THE TEMPLATES, BUT IM TOO TIRED
 		types := m.GetTypeDescArrayForStruct(m.GetInputTypeStruct())
 		for _, t := range types {
-			m.Query.AddParam("@"+t.ProtoName, fmt.Sprintf("req.%s", t.Name))
+			m.Query.AddParam("@"+t.ProtoName, fmt.Sprintf("req.Get%s()", t.Name))
 		}
 		//m.Spanner = s
 	} else if m.IsSQL() {

--- a/generator/persistence.go
+++ b/generator/persistence.go
@@ -72,6 +72,14 @@ func GenerateFileQueryContent(pkg PackagePath, file *FileStruct) PersistContent 
 			content.Content += stringer.QueryFunction(m)
 		}
 	}
+	for _, s := range *file.ServiceList {
+		if !s.IsSpanner() {
+			continue
+		}
+		for _, m := range *s.Methods {
+			content.Content += stringer.QueryInterfaceDefinition(m)
+		}
+	}
 	return content
 }
 func GenerateFilePersistHandlerContent(pkg PackagePath, file *FileStruct) PersistContent {

--- a/main.go
+++ b/main.go
@@ -45,7 +45,6 @@ func init() {
 	if os.Getenv("DEBUG") == "true" {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	logrus.Warn("main init()")
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -45,7 +45,7 @@ func init() {
 	if os.Getenv("DEBUG") == "true" {
 		logrus.SetLevel(logrus.DebugLevel)
 	}
-	logrus.Debug("main init()")
+	logrus.Warn("main init()")
 }
 
 func main() {
@@ -53,7 +53,6 @@ func main() {
 		fmt.Println("This executable is meant to be used by protoc!\nGo to http://github.com/tcncloud/protoc-gen-persist for more info")
 		os.Exit(-1)
 	}
-
 	var req plugin_go.CodeGeneratorRequest
 
 	data, err := ioutil.ReadAll(os.Stdin)


### PR DESCRIPTION
The functions that return a populated spanner statement or mutation now use an interface as a parameter instead of a struct.  Now more than one type can satisfy the function parameter.  Also all persist_lib input defintions have getter/setters generated. This will satisfy the interface required in the query function.